### PR TITLE
[Angel's Petro] Reduce flare stack costs.

### DIFF
--- a/prototypes/angelsmods/recipe-production.lua
+++ b/prototypes/angelsmods/recipe-production.lua
@@ -29,7 +29,7 @@ local multiply = marathomaton.multiply
 
 -- easy way: every machine in refining/metallurgy -> 4x upgrade AND .5x stone brick, AND
 -- ore silos 3x stone brick, AND
--- flare stack: 5x steel,
+-- flare stack stay the same; only used for discarding resources, and otherwise more expensive than chem plants.
 -- every building in barreling/pumps: 16x inputs
 
 
@@ -94,6 +94,3 @@ for recipe_name, recipe_obj in pairs(data.raw.recipe) do
     end
   end
 end
-
-multiply('steel-plate', 5.0, i2r({'angels-flare-stack', 'flare-stack'}))
-


### PR DESCRIPTION
Presently, flare stacks cost 200 steel plates, which makes them very
expensive compared to similarly tiered items. A refinery costs 60 steel,
a chemical plant 20, and a clarifier only 10.

Given the flare stack can only be used to discard resources, 200 steel
feels like a lot compared to other buildings which provide useful outputs.

This proposed change reduces the flare stack cost down to the original
40 steel plates, which still makes it a significant investment, but not
one which is out of line with refineries, chemical plants, and other
first tier oil equipment.