### PR TITLE
[Bob's Mods] Double enriched fuel costs

### DIFF
--- a/prototypes/recipe.lua
+++ b/prototypes/recipe.lua
@@ -12,6 +12,7 @@ local recipes
 marathomaton.modify_all_yields(0.5, 'sulfur')
 marathomaton.modify_all_yields(0.5, 'lubricant')
 multiply('__inputs__', 2.0, i2r({'solid-fuel'}))
+multiply('__inputs__', 2.0, i2r({'enriched-fuel'}))
 marathomaton.modify_all_recipes('plastic-bar', 2)
 
 -- slow down some select intermediates


### PR DESCRIPTION
Enriched fuel has a fuel value of 50MJ for a cost of 30 fuel oil.

Solid fuel (after marathomation tweaks) has a fuel value of 12MJ for a cost of 2 coke + 100 fuel oil.

Enriched fuel thus provides over four times the energy for less than one third the inputs, providing a 13-14x jump in energy conversion effectiveness. This is particularly large because marathomation currently doubles solid-fuel costs, but *not* enriched fuel costs.

This change doubles the cost of enriched fuel, making them less overpowered, and the tech energy jump not quite so steep.

Tested locally on Bob's Mods and Marathomation under Factorio 0.15.